### PR TITLE
feat: add the function to get the expressions and motions from the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ sprite.setExpression({ expressionId: 'smile' })
 await sprite.playVoice({
   voicePath: '/Resources/Hiyori/sounds/test.mp3',
 })
+
+// Get all available motions
+const motions = sprite.getMotions()
+// => [{ group: 'Idle', no: 0, name: 'Idle_0' }, { group: 'TapBody', no: 0, name: 'TapBody_0' }, ...]
+
+// Get all available expressions
+const expressions = sprite.getExpressions()
+// => [{ name: 'smile' }, { name: 'angry' }, ...]
 ```
 
 Voice decoding uses Web Audio `decodeAudioData()`, supporting any browser-decodable audio format (wav, mp3, ogg, etc.). Lip sync requires `LipSync` parameter mapping in the model.

--- a/README.zh.md
+++ b/README.zh.md
@@ -159,6 +159,14 @@ sprite.setExpression({ expressionId: 'smile' })
 await sprite.playVoice({
   voicePath: '/Resources/Hiyori/sounds/test.mp3',
 })
+
+// 获取模型所有动作列表
+const motions = sprite.getMotions()
+// => [{ group: 'Idle', no: 0, name: 'Idle_0' }, { group: 'TapBody', no: 0, name: 'TapBody_0' }, ...]
+
+// 获取模型所有表情列表
+const expressions = sprite.getExpressions()
+// => [{ name: 'smile' }, { name: 'angry' }, ...]
 ```
 
 语音解码基于 Web Audio `decodeAudioData()`，支持浏览器可解码的音频格式（wav、mp3、ogg 等）。口型同步需要模型配置 `LipSync` 参数映射。

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -146,6 +146,22 @@ sprite.releaseMotions(): void
 
 释放已加载的动作缓存。
 
+#### getMotions
+
+```ts
+sprite.getMotions(): MotionInfo[]
+```
+
+```ts
+interface MotionInfo {
+  group: string
+  no: number
+  name: string
+}
+```
+
+获取模型所有可用动作列表。返回每个动作的分组名、索引和名称。模型就绪前调用返回空数组。
+
 ### 表情控制
 
 #### setExpression
@@ -171,6 +187,20 @@ sprite.releaseExpressions(): void
 ```
 
 释放已加载的表情缓存。
+
+#### getExpressions
+
+```ts
+sprite.getExpressions(): ExpressionInfo[]
+```
+
+```ts
+interface ExpressionInfo {
+  name: string
+}
+```
+
+获取模型所有可用表情列表。模型就绪前调用返回空数组。
 
 ### 语音控制
 

--- a/docs/en/api/index.md
+++ b/docs/en/api/index.md
@@ -146,6 +146,22 @@ sprite.releaseMotions(): void
 
 Releases cached motion data.
 
+#### getMotions
+
+```ts
+sprite.getMotions(): MotionInfo[]
+```
+
+```ts
+interface MotionInfo {
+  group: string
+  no: number
+  name: string
+}
+```
+
+Returns all available motions of the model. Each entry contains the group name, index, and a combined name. Returns an empty array if called before the model is ready.
+
 ### Expression Control
 
 #### setExpression
@@ -171,6 +187,20 @@ sprite.releaseExpressions(): void
 ```
 
 Releases cached expression data.
+
+#### getExpressions
+
+```ts
+sprite.getExpressions(): ExpressionInfo[]
+```
+
+```ts
+interface ExpressionInfo {
+  name: string
+}
+```
+
+Returns all available expressions of the model. Returns an empty array if called before the model is ready.
 
 ### Voice Control
 

--- a/packages/core/src/Live2DSprite.ts
+++ b/packages/core/src/Live2DSprite.ts
@@ -5,9 +5,11 @@ import type {
 import type { CubismMotionQueueEntryHandle } from '@Framework/motion/cubismmotionqueuemanager'
 import type { DestroyOptions, Renderer, Size, Ticker } from 'pixi.js'
 import type {
+  ExpressionInfo,
   ExpressionParams,
   Live2DSpriteEvents,
   Live2DSpriteInit,
+  MotionInfo,
   MotionParams,
   Viewport,
   VoiceParams,
@@ -208,6 +210,14 @@ export class Live2DSprite extends Sprite {
 
   releaseExpressions(): void {
     this._model?.expressionCtrl.releaseExpressions()
+  }
+
+  getMotions(): MotionInfo[] {
+    return this._model?.getMotionInfos() ?? []
+  }
+
+  getExpressions(): ExpressionInfo[] {
+    return this._model?.getExpressionInfos() ?? []
   }
 
   onResize(): void {

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -61,6 +61,22 @@ export interface VoiceParams {
 }
 
 /**
+ * 动作信息
+ */
+export interface MotionInfo {
+  group: string
+  no: number
+  name: string
+}
+
+/**
+ * 表情信息
+ */
+export interface ExpressionInfo {
+  name: string
+}
+
+/**
  * 视口信息
  */
 export interface Viewport {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export { Live2DSprite } from './Live2DSprite'
 export { Config, ConfigType, LogLevel, Priority } from './utils/config'
 export { CubismSetting } from './utils/cubismSetting'
+export type { ExpressionInfo, MotionInfo } from './core/types'

--- a/packages/core/src/model/Live2DModel.ts
+++ b/packages/core/src/model/Live2DModel.ts
@@ -1,7 +1,7 @@
 import type { ICubismModelSetting } from '@Framework/icubismmodelsetting'
 import type { CubismMatrix44 } from '@Framework/math/cubismmatrix44'
 import type { EventBus } from '../core/EventBus'
-import type { Viewport } from '../core/types'
+import type { ExpressionInfo, MotionInfo, Viewport } from '../core/types'
 import type { IRedirectPath } from '../utils/cubismSetting'
 import { CubismUserModel } from '@Framework/model/cubismusermodel'
 import { csmMap as CsmMap } from '@Framework/type/csmmap'
@@ -204,5 +204,35 @@ export class Live2DModel extends CubismUserModel {
       x,
       y,
     )
+  }
+
+  getMotionInfos(): MotionInfo[] {
+    const setting = this._modelSettingRef
+    if (!setting)
+      return []
+
+    const result: MotionInfo[] = []
+    const groupCount = setting.getMotionGroupCount()
+    for (let i = 0; i < groupCount; i++) {
+      const group = setting.getMotionGroupName(i)
+      const count = setting.getMotionCount(group)
+      for (let no = 0; no < count; no++) {
+        result.push({ group, no, name: `${group}_${no}` })
+      }
+    }
+    return result
+  }
+
+  getExpressionInfos(): ExpressionInfo[] {
+    const setting = this._modelSettingRef
+    if (!setting)
+      return []
+
+    const result: ExpressionInfo[] = []
+    const count = setting.getExpressionCount()
+    for (let i = 0; i < count; i++) {
+      result.push({ name: setting.getExpressionName(i) })
+    }
+    return result
   }
 }

--- a/packages/playground/src/views/HomeView.vue
+++ b/packages/playground/src/views/HomeView.vue
@@ -77,8 +77,12 @@ onMounted(async () => {
     app.stage.addChild(live2DSprit2)
 
     // 模型加载完成后，打印原始尺寸信息
-    live2DSprite.onLive2D('ready', () => {
+    live2DSprit2.onLive2D('ready', () => {
       const size = live2DSprite.getModelCanvasSize()
+
+      console.log(live2DSprit2.getExpressions())
+
+      console.log(live2DSprit2.getMotions())
       if (size) {
         console.log('模型原始尺寸:', size.width, 'x', size.height)
       }


### PR DESCRIPTION
close: https://github.com/Panzer-Jack/easy-live2d/issues/35

---

This pull request adds new API methods to retrieve all available motions and expressions from a Live2D model, along with comprehensive documentation and type definitions. These enhancements make it easier for developers to access and display model capabilities programmatically.

**API Enhancements:**

* Added `getMotions()` and `getExpressions()` methods to the `Live2DSprite` class, allowing retrieval of all available motions and expressions from the model. These methods return arrays of the new `MotionInfo` and `ExpressionInfo` types, respectively. [[1]](diffhunk://#diff-ea4654542e79c53d2eaa5c9b71c8b0b010267d403306ef106968595ee4681782R215-R222) [[2]](diffhunk://#diff-95ede9bcad323c02afedb29354ab669c96f2c341f1eebc86b43a85c8a51be951R208-R237)

* Defined new TypeScript interfaces `MotionInfo` and `ExpressionInfo` in `core/types.ts` to describe the structure of motion and expression data. These types are now exported from the package entry point. [[1]](diffhunk://#diff-5568c2de390c6c2e485fa31193b6990318269eeacc8f07270843252bea2ac32fR63-R78) [[2]](diffhunk://#diff-9a4ceebe7c6f86856371906c3f061d3b56b7457022b05179884a113e7ced67e8R4)

**Documentation Updates:**

* Updated English and Chinese API documentation (`docs/en/api/index.md`, `docs/api/index.md`) to describe the new `getMotions()` and `getExpressions()` methods, including usage examples and interface details. [[1]](diffhunk://#diff-4675480f0737d029e15a0a18ac1cae4a0efd2fa80d2e346224b80cfdac30aa36R149-R164) [[2]](diffhunk://#diff-4675480f0737d029e15a0a18ac1cae4a0efd2fa80d2e346224b80cfdac30aa36R191-R204) [[3]](diffhunk://#diff-363e82493e2e04f41b234969fa9b7e9fe40d2a09b746ff381162a71206632657R149-R164) [[4]](diffhunk://#diff-363e82493e2e04f41b234969fa9b7e9fe40d2a09b746ff381162a71206632657R191-R204)

* Added example usage of the new methods to both the English and Chinese README files, demonstrating how to retrieve and inspect available motions and expressions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R162-R169) [[2]](diffhunk://#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8R162-R169)

**Demo/Testing:**

* Updated the playground demo (`HomeView.vue`) to log the results of `getMotions()` and `getExpressions()` after the model is loaded, showcasing the new functionality.