### PR TITLE
feat: support-index-to-set-expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,11 @@ await sprite.startMotion({
   priority: Priority.Force,
 })
 
-// Expressions
+// Expressions (by expressionId)
 sprite.setExpression({ expressionId: 'smile' })
+
+// Expressions (by index)
+sprite.setExpression({ index: 0 })
 
 // Voice with lip sync
 await sprite.playVoice({

--- a/README.zh.md
+++ b/README.zh.md
@@ -152,8 +152,11 @@ await sprite.startMotion({
   priority: Priority.Force,
 })
 
-// 表情切换
+// 表情切换（通过 expressionId）
 sprite.setExpression({ expressionId: 'smile' })
+
+// 表情切换（通过 index）
+sprite.setExpression({ index: 0 })
 
 // 语音播放（带口型同步）
 await sprite.playVoice({

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -167,10 +167,10 @@ interface MotionInfo {
 #### setExpression
 
 ```ts
-sprite.setExpression(params: { expressionId: string }): void
+sprite.setExpression(params: { expressionId: string } | { index: number }): void
 ```
 
-设置指定表情。`expressionId` 不存在时控制台输出警告。
+设置指定表情。支持通过 `expressionId` 或 `index` 指定，二选一。不存在时控制台输出警告。
 
 #### setRandomExpression
 

--- a/docs/en/api/index.md
+++ b/docs/en/api/index.md
@@ -167,10 +167,10 @@ Returns all available motions of the model. Each entry contains the group name, 
 #### setExpression
 
 ```ts
-sprite.setExpression(params: { expressionId: string }): void
+sprite.setExpression(params: { expressionId: string } | { index: number }): void
 ```
 
-Sets the specified expression. Logs a warning if `expressionId` does not exist.
+Sets the specified expression. Pass either `expressionId` or `index`. Logs a warning if the value does not exist.
 
 #### setRandomExpression
 

--- a/docs/en/guide/basic-usage.md
+++ b/docs/en/guide/basic-usage.md
@@ -175,12 +175,16 @@ After a motion finishes, the runtime falls back to the idle group specified by `
 ## Change Expressions
 
 ```ts
+// By expressionId
 sprite.setExpression({ expressionId: 'smile' })
+
+// By index
+sprite.setExpression({ index: 0 })
 
 sprite.setRandomExpression()
 ```
 
-A warning is logged if the `expressionId` does not exist.
+A warning is logged if the `expressionId` or `index` does not exist.
 
 ## Voice and Lip Sync
 

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -175,12 +175,16 @@ await sprite.startRandomMotion({
 ## 切换表情
 
 ```ts
+// 通过 expressionId
 sprite.setExpression({ expressionId: 'smile' })
+
+// 通过 index
+sprite.setExpression({ index: 0 })
 
 sprite.setRandomExpression()
 ```
 
-`expressionId` 不存在时会在控制台输出警告。
+`expressionId` 或 `index` 不存在时会在控制台输出警告。
 
 ## 语音与口型同步
 

--- a/packages/core/src/Live2DSprite.ts
+++ b/packages/core/src/Live2DSprite.ts
@@ -174,7 +174,13 @@ export class Live2DSprite extends Sprite {
   }
 
   setExpression(params: ExpressionParams): void {
-    const fn = () => this._model!.expressionCtrl.setExpression(params.expressionId)
+    const fn = () => {
+      if ('index' in params && params.index !== undefined) {
+        this._model!.expressionCtrl.setExpressionByIndex(params.index)
+      } else {
+        this._model!.expressionCtrl.setExpression(params.expressionId!)
+      }
+    }
     if (!this._model?.isReady) {
       this._preQueue.add(fn)
       return

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -46,11 +46,11 @@ export interface MotionParams {
 }
 
 /**
- * 表情设置参数
+ * 表情设置参数（expressionId 和 index 二选一）
  */
-export interface ExpressionParams {
-  expressionId: string
-}
+export type ExpressionParams =
+  | { expressionId: string, index?: never }
+  | { index: number, expressionId?: never }
 
 /**
  * 语音播放参数

--- a/packages/core/src/model/ExpressionController.ts
+++ b/packages/core/src/model/ExpressionController.ts
@@ -43,6 +43,26 @@ export class ExpressionController {
     }
   }
 
+  setExpressionByIndex(index: number): void {
+    if (index < 0 || index >= this._expressions.getSize()) {
+      console.warn(`Expression index ${index} out of range (0-${this._expressions.getSize() - 1})`)
+      return
+    }
+    let i = 0
+    for (
+      let iter = this._expressions.begin();
+      iter.notEqual(this._expressions.end());
+      iter.preIncrement()
+    ) {
+      if (i === index) {
+        const name = iter.ptr().first
+        this.setExpression(name)
+        return
+      }
+      i++
+    }
+  }
+
   setRandomExpression(): void {
     if (this._expressions.getSize() === 0)
       return


### PR DESCRIPTION
close: https://github.com/Panzer-Jack/easy-live2d/issues/37

--- 

This pull request adds support for setting model expressions by either `expressionId` or by their numeric `index`, improving flexibility and ease of use. The API, documentation, and implementation are all updated to reflect and support this new feature.

**API and Implementation Changes:**

* Updated the `ExpressionParams` type to accept either an `expressionId` or an `index`, ensuring only one can be provided at a time. (`packages/core/src/core/types.ts`)
* Modified `Live2DSprite.setExpression()` to handle both `expressionId` and `index`, delegating to a new method for index-based selection. (`packages/core/src/Live2DSprite.ts`)
* Added `ExpressionController.setExpressionByIndex()` to support selecting expressions by their index, with range checking and warnings for invalid indices. (`packages/core/src/model/ExpressionController.ts`)

**Documentation Updates:**

* Updated API documentation in both English and Chinese to describe the new usage of `setExpression` with either `expressionId` or `index`. (`docs/api/index.md`, `docs/en/api/index.md`) [[1]](diffhunk://#diff-363e82493e2e04f41b234969fa9b7e9fe40d2a09b746ff381162a71206632657L170-R173) [[2]](diffhunk://#diff-4675480f0737d029e15a0a18ac1cae4a0efd2fa80d2e346224b80cfdac30aa36L170-R173)
* Revised usage guides and code examples to demonstrate both methods of setting expressions, and clarified warning messages for invalid values. (`docs/guide/basic-usage.md`, `docs/en/guide/basic-usage.md`, `README.md`, `README.zh.md`) [[1]](diffhunk://#diff-570ae819d03df8bbbd9a577391a8b29242ba24c58d2e7737b068858d3647b98aR178-R187) [[2]](diffhunk://#diff-781a7cc0c98c5cea435ff663b26cfc0bb57869e89eeb84cf512882ef97cb853aR178-R187) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R160) [[4]](diffhunk://#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8L155-R160)