### PR TITLE
feat: add cubism core readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,10 @@ selenium-debug.log
 .cache/
 
 /packages/playground/public/
-/packages/cubism/Core/
+/packages/cubism/Core/*
+!/packages/cubism/Core/README.md
+!/packages/cubism/Core/README.ja.md
+!/packages/cubism/Core/RedistributableFiles.txt
 **/Samples/
 
 # 忽略 npm 锁文件，但保留 pnpm 锁文件

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
   <p align="center">
     <img src="https://github.com/user-attachments/assets/4ebc2d19-2ebe-4490-b214-e6ac8b350ce0" alt="easy-live2d" width="260">
   </p>
-  
+
   <h1>easy-live2d</h1>
-  
-  Making Live2D integration easier! A lightweight, developer-friendly Live2D Web SDK wrapper library based on Pixi.js.
-  
-  Make your Live2D as easy to control as a pixi sprite!
-  
+
+Making Live2D integration easier! A lightweight, developer-friendly Live2D Web SDK wrapper library based on Pixi.js.
+
+Make your Live2D as easy to control as a pixi sprite!
+
   <div align="center">
       <img src="https://img.shields.io/badge/node-%5E22.0.0-brightgreen" alt="license">
       <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license">
@@ -49,7 +49,7 @@ yarn add easy-live2d pixi.js
 
 ## Prerequisites
 
-1. Download and load the official `live2dcubismcore.js` in your entry HTML
+1. Download and load the official `live2dcubismcore.js`（[Live2D Cubism SDK for Web](https://www.live2d.com/en/sdk/download/web/)） in your entry HTML
 2. Browser environment (not SSR)
 3. An accessible Live2D `model3.json`
 
@@ -67,8 +67,17 @@ yarn add easy-live2d pixi.js
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>easy-live2d</title>
     <style>
-      html, body { margin: 0; width: 100%; height: 100%; }
-      #live2d { display: block; width: 100vw; height: 100vh; }
+      html,
+      body {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+      }
+      #live2d {
+        display: block;
+        width: 100vw;
+        height: 100vh;
+      }
     </style>
   </head>
   <body>
@@ -182,6 +191,18 @@ Voice decoding uses Web Audio `decodeAudioData()`, supporting any browser-decoda
 ## Live Demo
 
 - [StackBlitz Playground](https://stackblitz.com/~/github.com/Panzer-Jack/easy-live2d-playground?file=src/App.vue)
+
+## Development
+
+If you want to develop or contribute to this project locally, you need to manually download the Live2D Cubism SDK:
+
+1. Go to [Live2D Cubism SDK for Web](https://www.live2d.com/en/sdk/download/web/) and download the SDK
+2. Copy the following files from the SDK's `Core/` directory into `packages/cubism/Core/`:
+   - `live2dcubismcore.js`
+   - `live2dcubismcore.min.js`
+   - `live2dcubismcore.d.ts`
+
+> These files are not included in the repository due to Live2D's license restrictions.
 
 ## License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,13 +2,13 @@
   <p align="center">
       <img src="https://github.com/user-attachments/assets/4ebc2d19-2ebe-4490-b214-e6ac8b350ce0" alt="feuse-mcp" width="300px">
   </p>
-  
+
   <h1>easy-live2d</h1>
-  
-  让 Live2D 集成更简单！一个基于 Pixi.js 轻量、开发者友好的 Live2D Web SDK 封装库。
-  
-  让你的 Live2D 和操控 pixi sprite 一样简单！
-  
+
+让 Live2D 集成更简单！一个基于 Pixi.js 轻量、开发者友好的 Live2D Web SDK 封装库。
+
+让你的 Live2D 和操控 pixi sprite 一样简单！
+
   <div align="center">
       <img src="https://img.shields.io/badge/node-%5E22.0.0-brightgreen" alt="license">
       <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license">
@@ -49,7 +49,7 @@ yarn add easy-live2d pixi.js
 
 ## 前置条件
 
-1. 在页面入口引入官方 `live2dcubismcore.js`
+1. 在页面入口引入官方 `live2dcubismcore.js`（[Live2D Cubism SDK for Web](https://www.live2d.com/en/sdk/download/web/)）
 2. 浏览器环境（不支持 SSR）
 3. 可访问的 Live2D `model3.json` 模型文件
 
@@ -67,8 +67,17 @@ yarn add easy-live2d pixi.js
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>easy-live2d</title>
     <style>
-      html, body { margin: 0; width: 100%; height: 100%; }
-      #live2d { display: block; width: 100vw; height: 100vh; }
+      html,
+      body {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+      }
+      #live2d {
+        display: block;
+        width: 100vw;
+        height: 100vh;
+      }
     </style>
   </head>
   <body>
@@ -182,6 +191,21 @@ const expressions = sprite.getExpressions()
 ## 在线演示
 
 - [StackBlitz Playground](https://stackblitz.com/~/github.com/Panzer-Jack/easy-live2d-playground?file=src/App.vue)
+
+## 本地开发
+
+如果你想在本地开发或参与贡献本项目，需要手动下载 Live2D Cubism SDK：
+
+1. 前往 [Live2D Cubism SDK for Web](https://www.live2d.com/en/sdk/download/web/) 下载 SDK
+2. 将 SDK 中 `Core/` 目录下的以下文件复制到 `packages/cubism/Core/`：
+   - `live2dcubismcore.js`
+   - `live2dcubismcore.js.map`
+   - `live2dcubismcore.min.js`
+   - `live2dcubismcore.d.ts`
+   - `LICENSE.md`
+   - `CHANGELOG.md`
+
+> 由于 Live2D 许可证限制，这些文件未包含在仓库中。
 
 ## 许可证
 

--- a/packages/cubism/Core/README.ja.md
+++ b/packages/cubism/Core/README.ja.md
@@ -1,0 +1,39 @@
+[English](README.md) / [日本語](README.ja.md)
+
+---
+
+# Live2D Cubism Core
+
+このフォルダーには、JavaScriptまたはTypeScriptアプリケーションを開発するためのコアライブラリファイルが含まれています。
+
+## ⚠️ セットアップが必要です
+
+ライセンスの制約により、Cubism Core SDKファイルはこのリポジトリに含まれていません。開発前に手動でダウンロードする必要があります：
+
+1. [Live2D Cubism SDK for Web](https://www.live2d.com/en/sdk/download/web/) にアクセスしてSDKをダウンロードしてください
+2. 以下のファイルをこの `packages/cubism/Core/` フォルダーにコピーしてください：
+   - `live2dcubismcore.d.ts`
+   - `live2dcubismcore.js`
+   - `live2dcubismcore.min.js`
+
+## ファイルリスト
+
+### live2dcubismcore.d.ts
+
+このファイルには、`live2dcubismcore.js`に関するTypeScriptの型情報が含まれています。
+TypeScriptで開発する場合は、このファイルを`live2dcubismcore.js`とともに使用してください。
+
+### live2dcubismcore.js
+
+このファイルには、CubismCoreの機能といくつかのラッパーが含まれています。
+JavaScriptで開発する場合は、このファイルを使用してください。
+
+### live2dcubismcore.js.map
+
+このファイルは、`live2dcubismcore.d.ts`と`live2dcubismcore.js`の間のソースマップです。
+デバッグ時にこのファイルを使用します。
+
+### live2dcubismcore.min.js
+
+このファイルは、`live2dcubismcore.js`のminify版です。
+このファイルを本番環境で使用します。

--- a/packages/cubism/Core/README.md
+++ b/packages/cubism/Core/README.md
@@ -1,0 +1,29 @@
+[English](README.md) / [日本語](README.ja.md)
+
+---
+
+# Live2D Cubism Core
+
+This folder contains core library files for developing JavaScript or TypeScript applications.
+
+## File List
+
+### live2dcubismcore.d.ts
+
+This file contains typescript type information about `live2dcubismcore.js`.
+Use this file with `live2dcubismcore.js` when developing with TypeScript.
+
+### live2dcubismcore.js
+
+This file contains Cubism Core features and some wrapper features.
+Use this file when developing with JavaScript.
+
+### live2dcubismcore.js.map
+
+This file is the source map between `live2dcubismcore.d.ts` and `live2dcubismcore.js`.
+Use this file when debugging.
+
+### live2dcubismcore.min.js
+
+This file is the minified version of `live2dcubismcore.js`.
+Use this file in production.

--- a/packages/cubism/Core/RedistributableFiles.txt
+++ b/packages/cubism/Core/RedistributableFiles.txt
@@ -1,0 +1,6 @@
+The following is a list of files available for redistribution
+under the terms of the Live2D Proprietary Software License Agreement:
+
+- live2dcubismcore.d.ts
+- live2dcubismcore.js
+- live2dcubismcore.min.js


### PR DESCRIPTION
This pull request improves documentation and onboarding for developers working with the Live2D Cubism Core integration. It clarifies the manual steps required due to licensing restrictions, enhances both English and Chinese documentation, and adds a Japanese README for the core library. The most important changes are grouped below:

**Developer onboarding and SDK setup:**

* Added sections in both `README.md` and `README.zh.md` explaining that developers must manually download the Live2D Cubism SDK due to license restrictions, and specifying which files to copy into `packages/cubism/Core/`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195-R206) [[2]](diffhunk://#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8R195-R209)
* Added a new Japanese README (`README.ja.md`) in `packages/cubism/Core/` with instructions for manual SDK setup and file descriptions.
* Added a new English README (`README.md`) in `packages/cubism/Core/` describing the purpose of each core file.
* Added a `RedistributableFiles.txt` file listing which SDK files may be redistributed under the Live2D license.

**Documentation clarity and formatting:**

* Improved the SDK setup instructions in both English and Chinese main READMEs by adding direct download links and clarifying which files are needed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R52) [[2]](diffhunk://#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8L52-R52)
* Reformatted example HTML/CSS in both `README.md` and `README.zh.md` for better readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R80) [[2]](diffhunk://#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8L70-R80)