### PR TITLE
feat: update-readme-about-submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,24 @@ Voice decoding uses Web Audio `decodeAudioData()`, supporting any browser-decoda
 
 ## Development
 
-If you want to develop or contribute to this project locally, you need to manually download the Live2D Cubism SDK:
+If you want to develop or contribute to this project locally:
 
-1. Go to [Live2D Cubism SDK for Web](https://www.live2d.com/en/sdk/download/web/) and download the SDK
-2. Copy the following files from the SDK's `Core/` directory into `packages/cubism/Core/`:
+1. Clone the repository with submodules:
+
+```bash
+git clone --recursive https://github.com/Panzer-Jack/easy-live2d.git
+```
+
+If you've already cloned without `--recursive`, initialize the submodule manually:
+
+```bash
+git submodule update --init --recursive
+```
+
+This will pull `packages/cubism/Framework` (the Cubism Web Framework).
+
+2. Go to [Live2D Cubism SDK for Web](https://www.live2d.com/en/sdk/download/web/) and download the SDK
+3. Copy the following files from the SDK's `Core/` directory into `packages/cubism/Core/`:
    - `live2dcubismcore.js`
    - `live2dcubismcore.min.js`
    - `live2dcubismcore.d.ts`

--- a/README.zh.md
+++ b/README.zh.md
@@ -194,10 +194,24 @@ const expressions = sprite.getExpressions()
 
 ## 本地开发
 
-如果你想在本地开发或参与贡献本项目，需要手动下载 Live2D Cubism SDK：
+如果你想在本地开发或参与贡献本项目：
 
-1. 前往 [Live2D Cubism SDK for Web](https://www.live2d.com/en/sdk/download/web/) 下载 SDK
-2. 将 SDK 中 `Core/` 目录下的以下文件复制到 `packages/cubism/Core/`：
+1. 克隆仓库时带上子模块：
+
+```bash
+git clone --recursive https://github.com/Panzer-Jack/easy-live2d.git
+```
+
+如果已经克隆但没有带 `--recursive`，手动初始化子模块：
+
+```bash
+git submodule update --init --recursive
+```
+
+这会拉取 `packages/cubism/Framework`（Cubism Web Framework）。
+
+2. 前往 [Live2D Cubism SDK for Web](https://www.live2d.com/en/sdk/download/web/) 下载 SDK
+3. 将 SDK 中 `Core/` 目录下的以下文件复制到 `packages/cubism/Core/`：
    - `live2dcubismcore.js`
    - `live2dcubismcore.js.map`
    - `live2dcubismcore.min.js`


### PR DESCRIPTION
This pull request updates the development setup instructions in both the English (`README.md`) and Chinese (`README.zh.md`) documentation. The main improvement is that it now guides contributors to use git submodules for obtaining the Cubism Framework, making the setup process clearer and more streamlined.

Documentation improvements:

* Updated the development setup steps to instruct users to clone the repository with submodules using `git clone --recursive` and provided guidance for initializing submodules if already cloned. This ensures the Cubism Framework is automatically included. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L197-R214) [[2]](diffhunk://#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8L197-R214)
* Clarified the sequence of steps for downloading and copying the Live2D Cubism SDK core files after setting up the submodule. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L197-R214) [[2]](diffhunk://#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8L197-R214)